### PR TITLE
Fix CLI streaming by adding explicit output-format support

### DIFF
--- a/lib/claude_code/options.ex
+++ b/lib/claude_code/options.ex
@@ -115,7 +115,8 @@ defmodule ClaudeCode.Options do
       default: :default,
       doc: "Permission handling mode"
     ],
-    add_dir: [type: {:list, :string}, doc: "Additional directories for tool access"]
+    add_dir: [type: {:list, :string}, doc: "Additional directories for tool access"],
+    output_format: [type: :string, doc: "Output format (text, json, stream-json)"]
   ]
 
   @query_opts_schema [
@@ -131,7 +132,8 @@ defmodule ClaudeCode.Options do
       type: {:in, [:default, :accept_edits, :bypass_permissions]},
       doc: "Override permission mode for this query"
     ],
-    add_dir: [type: {:list, :string}, doc: "Override additional directories for this query"]
+    add_dir: [type: {:list, :string}, doc: "Override additional directories for this query"],
+    output_format: [type: :string, doc: "Override output format for this query"]
   ]
 
   # App config uses same option names directly - no mapping needed
@@ -367,6 +369,10 @@ defmodule ClaudeCode.Options do
       # Return a flat list of alternating flags and values
       Enum.flat_map(value, fn dir -> ["--add-dir", to_string(dir)] end)
     end
+  end
+
+  defp convert_option_to_cli_flag(:output_format, value) do
+    {"--output-format", to_string(value)}
   end
 
   defp convert_option_to_cli_flag(key, value) do

--- a/test/claude_code/options_test.exs
+++ b/test/claude_code/options_test.exs
@@ -184,7 +184,8 @@ defmodule ClaudeCode.OptionsTest do
         timeout: 120_000,
         allowed_tools: ["Bash(git:*)"],
         permission_mode: :bypass_permissions,
-        add_dir: ["/home/user/docs"]
+        add_dir: ["/home/user/docs"],
+        output_format: "stream-json"
       ]
 
       assert {:ok, validated} = Options.validate_query_options(opts)
@@ -193,6 +194,7 @@ defmodule ClaudeCode.OptionsTest do
       assert validated[:allowed_tools] == ["Bash(git:*)"]
       assert validated[:permission_mode] == :bypass_permissions
       assert validated[:add_dir] == ["/home/user/docs"]
+      assert validated[:output_format] == "stream-json"
     end
 
     test "accepts empty options" do
@@ -321,6 +323,28 @@ defmodule ClaudeCode.OptionsTest do
       args = Options.to_cli_args(opts)
       assert "--add-dir" in args
       assert "/single/path" in args
+    end
+
+    test "converts output_format to --output-format" do
+      opts = [output_format: "stream-json"]
+
+      args = Options.to_cli_args(opts)
+      assert "--output-format" in args
+      assert "stream-json" in args
+    end
+
+    test "converts output_format with different values" do
+      # Test text format
+      opts = [output_format: "text"]
+      args = Options.to_cli_args(opts)
+      assert "--output-format" in args
+      assert "text" in args
+
+      # Test json format
+      opts = [output_format: "json"]
+      args = Options.to_cli_args(opts)
+      assert "--output-format" in args
+      assert "json" in args
     end
   end
 


### PR DESCRIPTION
Hi everyone, 

I was playing with ClaudeCode and had the same error as https://github.com/guess/claude_code/issues/1 

Hopefully, Claude fixed the issue after a while. Hope this works for you!
Thank you for creating and maintaining this package!

## Problem

  Claude CLI automatically assumes `--print` mode when a prompt is provided as an argument, breaking streaming functionality and causing
  "Input must be provided either through stdin or as a prompt argument when using --print" errors.

  This makes the Claude Code Elixir library unusable for streaming applications.

  ## Solution

  Added explicit `--output-format` option support to allow programmatic control over Claude CLI's output mode:

  - Added `output_format` option to both session and query schemas
  - Implemented CLI flag conversion for `--output-format` parameter
  - Supports all Claude CLI formats: `"text"`, `"json"`, `"stream-json"`
  - Maintains full backwards compatibility

  ## Usage

  ```elixir
  # Force streaming mode to prevent --print assumption
  ClaudeCode.start_link(
    api_key: "sk-ant-...",
    output_format: "stream-json"
  )

  # Or override at query level
  ClaudeCode.query(session, "prompt", output_format: "text")

  Testing

  - ✅ All existing tests pass
  - ✅ Added comprehensive tests for new functionality
  - ✅ Verified streaming works with output_format: "stream-json"
  - ✅ Confirmed no regression in existing behavior

  Impact

  This enables reliable streaming functionality for programmatic usage while maintaining full backwards compatibility with existing
  applications.