### PR TITLE
fix: make result field optional in ResultMessage

### DIFF
--- a/lib/claude_code/message/result_message.ex
+++ b/lib/claude_code/message/result_message.ex
@@ -62,7 +62,6 @@ defmodule ClaudeCode.Message.ResultMessage do
     :duration_ms,
     :duration_api_ms,
     :num_turns,
-    :result,
     :session_id,
     :total_cost_usd,
     :usage
@@ -92,7 +91,7 @@ defmodule ClaudeCode.Message.ResultMessage do
           duration_ms: float(),
           duration_api_ms: float(),
           num_turns: non_neg_integer(),
-          result: String.t(),
+          result: String.t() | nil,
           session_id: Types.session_id(),
           total_cost_usd: float(),
           usage: Types.usage(),
@@ -122,7 +121,6 @@ defmodule ClaudeCode.Message.ResultMessage do
       "duration_ms",
       "duration_api_ms",
       "num_turns",
-      "result",
       "session_id",
       "total_cost_usd",
       "usage"
@@ -233,6 +231,11 @@ defmodule ClaudeCode.Message.ResultMessage do
   defp parse_permission_denials(_), do: nil
 end
 
-defimpl String.Chars, for: ClaudeCode.Message.Result do
+defimpl String.Chars, for: ClaudeCode.Message.ResultMessage do
+  def to_string(%{result: nil, errors: errors}) when is_list(errors) do
+    "Error: " <> Enum.join(errors, ", ")
+  end
+
+  def to_string(%{result: nil}), do: ""
   def to_string(%{result: result}), do: result
 end


### PR DESCRIPTION
## Summary

The `result` field can be `nil` for error messages which contain an `errors` array instead. This PR fixes the handling of error result messages from the CLI.

## Changes

- Remove `result` from `@enforce_keys` (no longer required)
- Update type spec to allow `nil`: `result: String.t() | nil`
- Remove `result` from required_fields validation
- Fix `String.Chars` protocol implementation:
  - Handle `nil` result with errors array
  - Handle `nil` result without errors
  - Display errors when result is nil
- Fix protocol implementation module name (`ResultMessage` instead of `Result`)

## Test Plan

- Error messages with `errors` array are properly handled
- Error messages without result field don't crash
- Success messages with result field continue to work as expected

This fixes issues when the CLI returns error results that don't have a `result` field.