### PR TITLE
Handle rate_limit_event messages from CLI

### DIFF
--- a/lib/claude_code/adapter/local.ex
+++ b/lib/claude_code/adapter/local.ex
@@ -503,6 +503,10 @@ defmodule ClaudeCode.Adapter.Local do
 
   defp handle_sdk_message(json, state) do
     case Parser.parse_message(json) do
+      {:ok, :rate_limit_event} ->
+        Logger.debug("[Adapter.Local] Received rate_limit_event (informational, no action needed)")
+        state
+
       {:ok, message} ->
         Adapter.notify_message(state.session, state.current_request, message)
 

--- a/lib/claude_code/cli/parser.ex
+++ b/lib/claude_code/cli/parser.ex
@@ -47,6 +47,7 @@ defmodule ClaudeCode.CLI.Parser do
       "user" -> UserMessage.new(data)
       "result" -> ResultMessage.new(data)
       "stream_event" -> PartialAssistantMessage.new(data)
+      "rate_limit_event" -> {:ok, :rate_limit_event}
       other -> {:error, {:unknown_message_type, other}}
     end
   end

--- a/test/claude_code/cli/parser_test.exs
+++ b/test/claude_code/cli/parser_test.exs
@@ -377,6 +377,19 @@ defmodule ClaudeCode.CLI.ParserTest do
       assert {:ok, %SystemMessage{subtype: :some_future_subtype}} = Parser.parse_message(data)
     end
 
+    test "handles rate_limit_event as informational message" do
+      msg = %{
+        "type" => "rate_limit_event",
+        "rate_limit_info" => %{
+          "status" => "allowed",
+          "rateLimitType" => "five_hour",
+          "resetsAt" => 1_772_110_800
+        }
+      }
+
+      assert {:ok, :rate_limit_event} = Parser.parse_message(msg)
+    end
+
     test "returns error for unknown message type" do
       assert {:error, {:unknown_message_type, "unknown"}} = Parser.parse_message(%{"type" => "unknown"})
     end


### PR DESCRIPTION
## Summary

- The Claude CLI sends `rate_limit_event` messages during streaming (with `status: "allowed"` etc.)
- These were falling through to `{:error, {:unknown_message_type, "rate_limit_event"}}` in `Parser.parse_message/1`, causing `"Failed to parse message"` debug logs
- Downstream, if the CLI pauses after sending a rate limit event, the stream can time out because no parseable messages arrive
- Now `rate_limit_event` is recognized in the parser and handled gracefully in the adapter as an informational no-op

## Changes

- `CLI.Parser.parse_message/1`: Added `"rate_limit_event"` clause returning `{:ok, :rate_limit_event}`
- `Adapter.Local.handle_sdk_message/2`: Added clause for `:rate_limit_event` that logs at debug level without notifying the session

## Test plan

- [ ] Existing tests still pass
- [ ] Verify with a real Claude CLI session that hits a rate limit window — no more "Failed to parse message" logs