### PR TITLE
docs: correct streaming configuration and clarify examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ClaudeCode.McpServerStatus` moved to `ClaudeCode.MCP.ServerStatus`** — Relocated to the MCP namespace. ([baaf9a7])
 - **`ClaudeCode.ModelInfo` boolean fields default to `false`** — Fields like `supports_thinking`, `supports_computer_use`, etc. now default to `false` instead of `nil`. ([f6b38e5])
 - **Upgraded bundled CLI to 2.1.70** ([ac24906])
+- **Streaming docs/examples corrected for partial-message behavior** — Documentation and examples now consistently show partial streaming configured at session start (`ClaudeCode.start_link(include_partial_messages: true)`) and streamed with `ClaudeCode.stream/2` or `ClaudeCode.stream/3`, with stale partial-stream module guidance removed.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ session
 # => "Your favorite language is Elixir!"
 ```
 
+## Example Scripts
+
+See [`examples/README.md`](examples/README.md) for runnable examples including streaming and character-level streaming with `include_partial_messages: true`.
+
 ## Features
 
 ### In-Process Custom Tools
@@ -120,9 +124,11 @@ Pass per-session context via assigns for scoped tools in LiveView:
 Native Elixir Streams with character-level deltas, composable pipelines, and direct LiveView integration:
 
 ```elixir
+{:ok, session} = ClaudeCode.start_link(include_partial_messages: true)
+
 # Character-level streaming
 session
-|> ClaudeCode.stream("Explain recursion", include_partial_messages: true)
+|> ClaudeCode.stream("Explain recursion")
 |> ClaudeCode.Stream.text_deltas()
 |> Enum.each(&IO.write/1)
 
@@ -130,19 +136,19 @@ session
 pid = self()
 Task.start(fn ->
   session
-  |> ClaudeCode.stream(message, include_partial_messages: true)
+  |> ClaudeCode.stream(message)
   |> ClaudeCode.Stream.text_deltas()
   |> Enum.each(&send(pid, {:chunk, &1}))
 end)
 
 # PubSub broadcasting
 session
-|> ClaudeCode.stream("Generate report", include_partial_messages: true)
+|> ClaudeCode.stream("Generate report")
 |> ClaudeCode.Stream.text_deltas()
 |> Enum.each(&Phoenix.PubSub.broadcast(MyApp.PubSub, "chat:#{id}", {:chunk, &1}))
 ```
 
-Stream helpers: `text_deltas/1`, `thinking_deltas/1`, `text_content/1`, `tool_uses/1`, `final_text/1`, `collect/1`, `buffered_text/1`, and more.
+Stream helpers: `text_deltas/1`, `thinking_deltas/1`, `content_deltas/1`, `text_content/1`, `tool_uses/1`, `final_text/1`, `final_result/1`, `collect/1`, and more.
 
 [Streaming guide →](docs/guides/streaming-output.md)
 

--- a/docs/guides/distributed-sessions.md
+++ b/docs/guides/distributed-sessions.md
@@ -171,6 +171,7 @@ defmodule MyAppWeb.ChatLive do
       cwd: "/workspaces/#{user_id}",
       model: "claude-sonnet-4-20250514",
       permission_mode: :dont_ask,
+      include_partial_messages: true,
       adapter: {ClaudeCode.Adapter.Node, [node: :"claude@sandbox"]}
     )
 
@@ -186,7 +187,7 @@ defmodule MyAppWeb.ChatLive do
       Task.Supervisor.start_child(MyApp.TaskSupervisor, fn ->
         try do
           socket.assigns.claude
-          |> ClaudeCode.stream(msg, include_partial_messages: true)
+          |> ClaudeCode.stream(msg)
           |> ClaudeCode.Stream.text_deltas()
           |> Enum.each(&send(lv, {:chunk, &1}))
 
@@ -409,6 +410,7 @@ All `ClaudeCode.Stream` utilities work identically over distributed sessions. Me
 ```elixir
 {:ok, session} = ClaudeCode.start_link(
   cwd: "/workspaces/project",
+  include_partial_messages: true,
   adapter: {ClaudeCode.Adapter.Node, [node: :"claude@sandbox"]}
 )
 
@@ -420,7 +422,7 @@ session
 
 # Character-level deltas
 session
-|> ClaudeCode.stream("Write a haiku", include_partial_messages: true)
+|> ClaudeCode.stream("Write a haiku")
 |> ClaudeCode.Stream.text_deltas()
 |> Enum.each(&IO.write/1)
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -132,6 +132,8 @@ Every hook callback receives two arguments:
 
 Both modules implementing `ClaudeCode.Hook` and anonymous functions receive the same arguments via `call/2`.
 
+> **Key normalization:** Known hook fields are normalized to atom keys (for ergonomic pattern matching). Unknown or future fields are preserved as string keys to avoid unbounded runtime atom creation.
+
 ### Input data
 
 The first argument to your hook callback contains information about the event.

--- a/docs/guides/hosting.md
+++ b/docs/guides/hosting.md
@@ -196,7 +196,8 @@ defmodule MyAppWeb.ChatLive do
 
   def mount(_params, _session, socket) do
     {:ok, session} = ClaudeCode.start_link(
-      system_prompt: "You are a helpful assistant."
+      system_prompt: "You are a helpful assistant.",
+      include_partial_messages: true
     )
 
     {:ok, assign(socket, claude: session)}
@@ -205,7 +206,7 @@ defmodule MyAppWeb.ChatLive do
   def handle_event("send", %{"message" => msg}, socket) do
     Task.start(fn ->
       socket.assigns.claude
-      |> ClaudeCode.stream(msg, include_partial_messages: true)
+      |> ClaudeCode.stream(msg)
       |> ClaudeCode.Stream.text_deltas()
       |> Enum.each(&send(socket.root_pid, {:chunk, &1}))
 

--- a/docs/guides/streaming-output.md
+++ b/docs/guides/streaming-output.md
@@ -8,13 +8,13 @@ Get real-time responses from the Agent SDK as text and tool calls stream in.
 
 ---
 
-By default, the SDK yields complete `AssistantMessage` structs after Claude finishes generating each response. To receive incremental updates as text and tool calls are generated, enable partial message streaming by setting `include_partial_messages: true` in your options.
+By default, the SDK yields complete `AssistantMessage` structs after Claude finishes generating each response. To receive incremental updates as text and tool calls are generated, start the session with `include_partial_messages: true`.
 
 > **Tip:** This page covers output streaming (receiving tokens in real-time). For input modes (how you send messages), see [Streaming vs Single Mode](streaming-vs-single-mode.md). You can also [stream responses using the Agent SDK via the CLI](https://code.claude.com/docs/en/headless).
 
 ## Enable streaming output
 
-To enable streaming, set `include_partial_messages: true` in your options. This causes the SDK to yield `PartialAssistantMessage` structs containing raw API events as they arrive, in addition to the usual `AssistantMessage` and `ResultMessage`.
+To enable streaming, set `include_partial_messages: true` when calling `ClaudeCode.start_link/1`. This causes the SDK to yield `PartialAssistantMessage` structs containing raw API events as they arrive, in addition to the usual `AssistantMessage` and `ResultMessage`.
 
 > **Tip:** The `ClaudeCode.Stream` module provides convenience functions like `ClaudeCode.Stream.text_deltas/1` that handle the pattern matching shown below. See the [Convenience functions](#convenience-functions) section for the full list.
 
@@ -47,7 +47,7 @@ Or use the convenience function:
 
 ```elixir
 session
-|> ClaudeCode.stream("List the files in my project", include_partial_messages: true)
+|> ClaudeCode.stream("List the files in my project")
 |> ClaudeCode.Stream.text_deltas()
 |> Enum.each(&IO.write/1)
 ```
@@ -121,7 +121,7 @@ Or use the convenience function:
 
 ```elixir
 session
-|> ClaudeCode.stream("Explain how databases work", include_partial_messages: true)
+|> ClaudeCode.stream("Explain how databases work")
 |> ClaudeCode.Stream.text_deltas()
 |> Enum.each(&IO.write/1)
 ```
@@ -206,7 +206,7 @@ defmodule MyAppWeb.ChatLive do
 
     Task.start(fn ->
       session
-      |> ClaudeCode.stream(message, include_partial_messages: true)
+      |> ClaudeCode.stream(message)
       |> ClaudeCode.Stream.text_deltas()
       |> Enum.each(&send(socket.root_pid, {:text_chunk, &1}))
 
@@ -230,7 +230,7 @@ For multi-subscriber broadcasting, use PubSub:
 
 ```elixir
 session
-|> ClaudeCode.stream("Generate report", include_partial_messages: true)
+|> ClaudeCode.stream("Generate report")
 |> ClaudeCode.Stream.text_deltas()
 |> Enum.each(&Phoenix.PubSub.broadcast(MyApp.PubSub, "chat:#{chat_id}", {:text_chunk, &1}))
 ```
@@ -239,7 +239,7 @@ session
 
 The Elixir SDK provides high-level stream utilities that handle the pattern matching shown above.
 
-**Partial message streams** (`include_partial_messages: true`):
+**Partial message streams** (when session is started with `include_partial_messages: true`):
 
 | Function | Description |
 |:---------|:------------|

--- a/docs/integration/phoenix.md
+++ b/docs/integration/phoenix.md
@@ -12,7 +12,7 @@ def start(_type, _args) do
   children = [
     MyAppWeb.Endpoint,
     {ClaudeCode.Supervisor, [
-      [name: :assistant]
+      [name: :assistant, include_partial_messages: true]
     ]}
   ]
 
@@ -35,7 +35,7 @@ defmodule MyAppWeb.ChatLive do
 
     Task.start(fn ->
       :assistant
-      |> ClaudeCode.stream(message, include_partial_messages: true)
+      |> ClaudeCode.stream(message)
       |> ClaudeCode.Stream.text_deltas()
       |> Enum.each(fn chunk ->
         send(parent, {:chunk, chunk})
@@ -136,7 +136,7 @@ defmodule MyApp.ClaudeStreamer do
   def stream_to_topic(prompt, topic) do
     Task.start(fn ->
       :assistant
-      |> ClaudeCode.stream(prompt, include_partial_messages: true)
+      |> ClaudeCode.stream(prompt)
       |> ClaudeCode.Stream.text_deltas()
       |> Enum.each(fn chunk ->
         Phoenix.PubSub.broadcast(MyApp.PubSub, topic, {:claude_chunk, chunk})
@@ -181,10 +181,9 @@ defmodule MyApp.Claude do
 
   def stream(prompt, opts \\ []) do
     session = Keyword.get(opts, :session, :assistant)
-    include_partial = Keyword.get(opts, :partial, true)
 
     session
-    |> ClaudeCode.stream(prompt, include_partial_messages: include_partial)
+    |> ClaudeCode.stream(prompt)
     |> ClaudeCode.Stream.text_deltas()
   end
 end

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,52 @@
+# Examples
+
+Run these scripts from the repo root.
+
+## Available scripts
+
+- `examples/streaming_example.exs` - complete-message streaming helpers and raw-message handling
+- `examples/character_streaming_example.exs` - partial-message streaming with `include_partial_messages: true`
+
+## Default run command
+
+If you use the SDK's default bundled CLI configuration, run:
+
+```bash
+mix run examples/streaming_example.exs
+mix run examples/character_streaming_example.exs
+```
+
+## Using a system-installed Claude CLI
+
+If you want the examples to use an external `claude` binary instead of the bundled one, set:
+
+```elixir
+# config/dev.exs
+import Config
+
+config :claude_code, cli_path: :global
+```
+
+Then run the same commands:
+
+```bash
+mix run examples/streaming_example.exs
+mix run examples/character_streaming_example.exs
+```
+
+## One-off override without editing config
+
+If you do not want to change `config/dev.exs`, require the example file from `-e` after setting `:cli_path`:
+
+```bash
+mix run -e 'Application.put_env(:claude_code, :cli_path, :global); Code.require_file("streaming_example.exs", "examples")'
+mix run -e 'Application.put_env(:claude_code, :cli_path, :global); Code.require_file("character_streaming_example.exs", "examples")'
+```
+
+This form matters: `mix run -e '...' examples/foo.exs` only evaluates the expression and does not also run the script.
+
+## Requirements
+
+- Run from the repository root so the relative `examples` path resolves correctly.
+- Ensure the external `claude` binary is on your `PATH` when using `cli_path: :global`.
+- Authenticate the Claude CLI first with either `ANTHROPIC_API_KEY` or `claude /login`.

--- a/examples/character_streaming_example.exs
+++ b/examples/character_streaming_example.exs
@@ -1,88 +1,88 @@
 #!/usr/bin/env elixir
 # Example of using character-level streaming for real-time output
 #
+# Run instructions:
+#   See examples/README.md
+#
 # This demonstrates the `include_partial_messages: true` option which enables
 # character-by-character streaming from Claude's responses - perfect for
 # building responsive chat interfaces and LiveView applications.
 
-# Start a session
-{:ok, session} = ClaudeCode.start_link()
+alias ClaudeCode.Message.PartialAssistantMessage
+
+# Partial message streaming is configured when the CLI session starts.
+{:ok, standard_session} = ClaudeCode.start_link()
+{:ok, partial_session} = ClaudeCode.start_link(include_partial_messages: true)
 
 IO.puts("Example 1: Basic Character Streaming")
-IO.puts("=" |> String.duplicate(60))
+"=" |> String.duplicate(60) |> IO.puts()
 IO.puts("Watch the text appear character by character:\n")
 
-session
-|> ClaudeCode.stream("Count from 1 to 5, spelling out each number", include_partial_messages: true)
+partial_session
+|> ClaudeCode.stream("Count from 1 to 5, spelling out each number")
 |> ClaudeCode.Stream.text_deltas()
-|> Stream.each(&IO.write/1)
-|> Stream.run()
+|> Enum.each(&IO.write/1)
 
 IO.puts("\n\n")
 
 IO.puts("Example 2: Comparing Complete vs Partial Message Streaming")
-IO.puts("=" |> String.duplicate(60))
+"=" |> String.duplicate(60) |> IO.puts()
 
 IO.puts("\nWith include_partial_messages: false (default):")
 IO.puts("Each chunk is a complete message:\n")
 
-session
+standard_session
 |> ClaudeCode.stream("Say 'Hello World'")
 |> ClaudeCode.Stream.text_content()
-|> Stream.each(fn chunk ->
+|> Enum.each(fn chunk ->
   IO.puts("[chunk: #{inspect(chunk)}]")
 end)
-|> Stream.run()
 
 IO.puts("\nWith include_partial_messages: true:")
 IO.puts("Each chunk is a character/token:\n")
 
-session
-|> ClaudeCode.stream("Say 'Hello World'", include_partial_messages: true)
+partial_session
+|> ClaudeCode.stream("Say 'Hello World'")
 |> ClaudeCode.Stream.text_deltas()
-|> Stream.each(fn chunk ->
+|> Enum.each(fn chunk ->
   IO.puts("[delta: #{inspect(chunk)}]")
 end)
-|> Stream.run()
 
 IO.puts("\n")
 
 IO.puts("Example 3: Working with Content Deltas")
-IO.puts("=" |> String.duplicate(60))
+"=" |> String.duplicate(60) |> IO.puts()
 IO.puts("Content deltas include index and type information:\n")
 
-session
-|> ClaudeCode.stream("Hi there!", include_partial_messages: true)
+partial_session
+|> ClaudeCode.stream("Hi there!")
 |> ClaudeCode.Stream.content_deltas()
-|> Stream.each(fn delta ->
+|> Enum.each(fn delta ->
   IO.inspect(delta, label: "delta")
 end)
-|> Stream.run()
 
 IO.puts("\n")
 
 IO.puts("Example 4: Filtering Stream Events by Type")
-IO.puts("=" |> String.duplicate(60))
+"=" |> String.duplicate(60) |> IO.puts()
 IO.puts("Different event types during streaming:\n")
 
-alias ClaudeCode.Message.PartialAssistantMessage
-
-session
-|> ClaudeCode.stream("Hello", include_partial_messages: true)
+partial_session
+|> ClaudeCode.stream("Hello")
 |> Stream.filter(&match?(%PartialAssistantMessage{}, &1))
-|> Stream.each(fn %PartialAssistantMessage{event: event} ->
+|> Enum.each(fn %PartialAssistantMessage{event: event} ->
   IO.puts("Event type: #{event.type}")
 end)
-|> Stream.run()
 
 IO.puts("\n")
 
 IO.puts("Example 5: LiveView-style PubSub Pattern")
-IO.puts("=" |> String.duplicate(60))
+"=" |> String.duplicate(60) |> IO.puts()
 IO.puts("Simulating how you'd use this with Phoenix PubSub:\n")
 
 # Simulate a PubSub broadcast (in real app, use Phoenix.PubSub)
 defmodule FakePubSub do
+  @moduledoc false
   def broadcast(topic, message) do
     IO.puts("  [PubSub #{topic}] #{inspect(message)}")
   end
@@ -90,24 +90,23 @@ end
 
 session_id = "chat:12345"
 
-session
-|> ClaudeCode.stream("Say hi", include_partial_messages: true)
+partial_session
+|> ClaudeCode.stream("Say hi")
 |> ClaudeCode.Stream.text_deltas()
-|> Stream.each(fn text_chunk ->
+|> Enum.each(fn text_chunk ->
   # In a real app: Phoenix.PubSub.broadcast(MyApp.PubSub, topic, message)
   FakePubSub.broadcast(session_id, {:text_chunk, text_chunk})
 end)
-|> Stream.run()
 
 IO.puts("\n")
 
 IO.puts("Example 6: Accumulating Text with Real-time Display")
-IO.puts("=" |> String.duplicate(60))
+"=" |> String.duplicate(60) |> IO.puts()
 IO.puts("Building up the full response while streaming:\n")
 
 {chunks, final_text} =
-  session
-  |> ClaudeCode.stream("List three colors", include_partial_messages: true)
+  partial_session
+  |> ClaudeCode.stream("List three colors")
   |> ClaudeCode.Stream.text_deltas()
   |> Enum.reduce({[], ""}, fn chunk, {chunks, acc} ->
     IO.write(chunk)
@@ -120,17 +119,16 @@ IO.puts("Final text length: #{String.length(final_text)} characters")
 IO.puts("\n")
 
 IO.puts("Example 7: Timing Analysis")
-IO.puts("=" |> String.duplicate(60))
+"=" |> String.duplicate(60) |> IO.puts()
 IO.puts("Measuring time-to-first-token:\n")
 
 start_time = System.monotonic_time(:millisecond)
-first_chunk_time = nil
 
-session
-|> ClaudeCode.stream("Write a haiku", include_partial_messages: true)
+partial_session
+|> ClaudeCode.stream("Write a haiku")
 |> ClaudeCode.Stream.text_deltas()
 |> Stream.with_index()
-|> Stream.each(fn {chunk, index} ->
+|> Enum.each(fn {chunk, index} ->
   current_time = System.monotonic_time(:millisecond)
 
   if index == 0 do
@@ -140,13 +138,13 @@ session
 
   IO.write(chunk)
 end)
-|> Stream.run()
 
 total_time = System.monotonic_time(:millisecond) - start_time
 IO.puts("\n[Total streaming time: #{total_time}ms]")
 
 # Clean up
-ClaudeCode.stop(session)
+ClaudeCode.stop(standard_session)
+ClaudeCode.stop(partial_session)
 
 IO.puts("\n" <> String.duplicate("=", 60))
 IO.puts("Character streaming examples complete!")

--- a/examples/streaming_example.exs
+++ b/examples/streaming_example.exs
@@ -1,47 +1,51 @@
 #!/usr/bin/env elixir
 # Example of using the ClaudeCode streaming API
+#
+# Run instructions:
+#   See examples/README.md
+
+alias ClaudeCode.Message.AssistantMessage
+alias ClaudeCode.Message.ResultMessage
 
 # Start a session
-{:ok, session} = ClaudeCode.start_link(api_key: System.get_env("ANTHROPIC_API_KEY"))
+{:ok, session} = ClaudeCode.start_link()
 
 IO.puts("Example 1: Using Stream.text_content() helper (recommended)")
-IO.puts("=" |> String.duplicate(60))
+"=" |> String.duplicate(60) |> IO.puts()
 
 session
 |> ClaudeCode.stream("Explain GenServers in Elixir in 2 sentences")
 |> ClaudeCode.Stream.text_content()
-|> Stream.each(&IO.write/1)
-|> Stream.run()
+|> Enum.each(&IO.write/1)
 
 IO.puts("\n\n")
 
 IO.puts("Example 2: Working with raw messages")
-IO.puts("=" |> String.duplicate(60))
+"=" |> String.duplicate(60) |> IO.puts()
 
 session
 |> ClaudeCode.stream("What is pattern matching?")
-|> Stream.each(fn message ->
+|> Enum.each(fn message ->
   case message do
-    %ClaudeCode.Message.Assistant{message: %{content: content}} ->
+    %AssistantMessage{message: %{content: content}} ->
       # Extract text from content blocks
       Enum.each(content, fn
         %ClaudeCode.Content.TextBlock{text: text} -> IO.write(text)
         _ -> :ok
       end)
 
-    %ClaudeCode.Message.Result{result: result} ->
+    %ResultMessage{result: result} ->
       IO.puts("\n\nFinal result: #{result}")
 
     _ ->
       :ok
   end
 end)
-|> Stream.run()
 
 IO.puts("\n")
 
 IO.puts("Example 3: Filtering for specific message types")
-IO.puts("=" |> String.duplicate(60))
+"=" |> String.duplicate(60) |> IO.puts()
 
 # Collect only assistant messages
 messages =
@@ -54,14 +58,15 @@ IO.puts("Received #{length(messages)} assistant messages")
 
 IO.puts("\n")
 
-IO.puts("Example 4: Using buffered text for complete sentences")
-IO.puts("=" |> String.duplicate(60))
+IO.puts("Example 4: Using Stream.final_text() for one-shot output")
+"=" |> String.duplicate(60) |> IO.puts()
 
-session
-|> ClaudeCode.stream("Tell me about OTP")
-|> ClaudeCode.Stream.buffered_text()
-|> Stream.each(&IO.puts/1)
-|> Stream.run()
+final_text =
+  session
+  |> ClaudeCode.stream("Tell me about OTP")
+  |> ClaudeCode.Stream.final_text()
+
+IO.puts(final_text || "[no final text received]")
 
 # Clean up
 ClaudeCode.stop(session)


### PR DESCRIPTION
## Summary

Extracted documentation and examples updates from PR #18 to fix streaming configuration guidance and clarify how to run examples.

## Changes

- **Streaming configuration**: Moved `include_partial_messages: true` from query-time to session start in all documentation and examples
- **Examples guide**: Added `examples/README.md` with comprehensive instructions for running examples (bundled CLI, system-installed CLI, one-off overrides)
- **README**: Added concise "Example Scripts" section pointing to the full examples guide
- **Stream helpers**: Updated list to show current helpers (`content_deltas/1`, `final_result/1` added; `buffered_text/1` removed)
- **Hook guide**: Added note on key normalization for atom safety
- **CHANGELOG**: Documented streaming docs/examples corrections

## Testing

- All documentation renders correctly
- Examples demonstrate the correct API usage pattern