### PR TITLE
Add upstream source file tracking to cli-sync skill

### DIFF
--- a/.claude/skills/cli-sync/SKILL.md
+++ b/.claude/skills/cli-sync/SKILL.md
@@ -12,7 +12,7 @@ Synchronize the ClaudeCode Elixir SDK with the Claude CLI to detect schema chang
 
 The Claude CLI evolves independently of this SDK. This skill dispatches five parallel agents to check alignment across all layers: versions, message types, content blocks, control protocol, and CLI options. Each agent has self-contained instructions in a `references/check-*.md` file.
 
-**Canonical sources**: The TypeScript SDK (`@anthropic-ai/claude-agent-sdk`) provides the `SDKMessage` union (message types) and `SDKControl*` types (control protocol). The Anthropic API SDK (`@anthropic-ai/sdk`) provides `BetaContentBlock` types. The Python SDK (`claude-agent-sdk-python`) provides cross-reference for options and field names.
+**Canonical sources**: The TypeScript SDK (`@anthropic-ai/claude-agent-sdk`) provides the `SDKMessage` union (message types) and `SDKControl*` types (control protocol). The Anthropic API SDK (`@anthropic-ai/sdk`) provides `BetaContentBlock` types. The Python SDK (`claude-agent-sdk-python`) provides cross-reference for options, field names, control protocol handling, and message parsing. See `references/upstream-sources.md` for the complete file-level mapping.
 
 ## Workflow
 

--- a/.claude/skills/cli-sync/references/check-control-protocol.md
+++ b/.claude/skills/cli-sync/references/check-control-protocol.md
@@ -15,6 +15,11 @@ missing public API accessors for initialize response data.
 
 - `captured/ts-sdk-types.d.ts` — search for all `SDKControl*` type definitions
   (request types, response types, and related interfaces)
+- `captured/python-sdk-query.py` — control request/response handling logic,
+  hook dispatch, `can_use_tool` routing, MCP message routing. Cross-reference
+  for control flow patterns and request subtypes.
+- `captured/python-sdk-client.py` — option validation and mutual exclusion
+  rules (e.g., `can_use_tool` vs `permission_prompt_tool_name`)
 
 ### Elixir implementation
 

--- a/.claude/skills/cli-sync/references/check-message-types.md
+++ b/.claude/skills/cli-sync/references/check-message-types.md
@@ -12,6 +12,7 @@ Detect coverage gaps in the Elixir SDK's message type handling. Compare the cano
 
 - `captured/ts-sdk-types.d.ts` -- Extract the `SDKMessage` union type and all member type definitions. This is the canonical source of truth for all message types the CLI can emit.
 - `captured/python-sdk-types.py` -- Cross-reference the Python SDK's `Message` union (a subset of ~5 types). Useful for confirming wire type strings and field names.
+- `captured/python-sdk-message-parser.py` -- Message parsing dispatch logic. Shows how the Python SDK maps wire type strings to typed objects, including subtype handling for system messages.
 
 ### Elixir implementation
 

--- a/.claude/skills/cli-sync/references/check-options.md
+++ b/.claude/skills/cli-sync/references/check-options.md
@@ -14,6 +14,7 @@ Detect new, removed, or changed CLI flags and SDK options by comparing CLI help 
 - `captured/ts-sdk-types.d.ts` -- Search for the `ClaudeAgentOptions` or `Options` type definition. Extract all option names and their types.
 - `captured/python-sdk-subprocess-cli.py` -- The `_build_command()` method showing how the Python SDK maps options to CLI flags.
 - `captured/python-sdk-types.py` -- Python SDK's options type definitions (class fields and their types).
+- `captured/python-sdk-client.py` -- Internal client showing option validation, mutual exclusion rules (e.g., `can_use_tool` vs `permission_prompt_tool_name`), and agent/hook preprocessing.
 
 ### Elixir implementation
 

--- a/.claude/skills/cli-sync/references/upstream-sources.md
+++ b/.claude/skills/cli-sync/references/upstream-sources.md
@@ -1,0 +1,86 @@
+# Upstream Source Files to Track
+
+Key files in the upstream SDKs that drive changes in the Elixir SDK. Changes to these files
+typically require corresponding updates. Organized by sync priority.
+
+## TypeScript SDK (`@anthropic-ai/claude-agent-sdk`)
+
+Source is **not public on GitHub** — types are distributed via npm as `.d.ts` files.
+Fetched by `scripts/capture-cli-data.sh` from unpkg CDN.
+
+| File | Captured As | What to Watch For | Elixir Modules Affected |
+|---|---|---|---|
+| `sdk.d.ts` | `ts-sdk-types.d.ts` | **Primary source for all sync checks** | — |
+| ↳ `SDKMessage` union (~line 1922) | — | New message type variants | `message/`, `cli/parser.ex` |
+| ↳ `Options` type (~line 697) | — | New session/query options | `options.ex`, `cli/command.ex` |
+| ↳ `SDKControlRequestInner` union (~line 1758) | — | New control protocol operations | `cli/control.ex`, `cli/input.ex`, `adapter/port.ex` |
+| ↳ `Query` interface (~line 1353) | — | New runtime control methods | `session.ex`, `session/server.ex` |
+| ↳ `SDKControlInitializeResponse` | — | New init response fields | `adapter/port.ex`, `cli/control.ex` |
+| ↳ Hook types (`HookEvent`, `HookInput`, etc.) | — | New hook events (currently 21) | `hook.ex` and related |
+| ↳ Permission types (`CanUseTool`, etc.) | — | Permission callback changes | `options.ex`, `adapter/port.ex` |
+| ↳ MCP types (`McpServerStatus`, etc.) | — | MCP config/status changes | `mcp/status.ex`, `options.ex` |
+| ↳ `SDKSession` / V2 session API | — | New persistent session API (unstable) | Future: `session.ex` |
+| `sdk-tools.d.ts` | *(not captured)* | Tool input/output schemas | Content blocks (if validating) |
+
+## Anthropic API SDK (`@anthropic-ai/sdk`)
+
+Content block types come from the Anthropic API, not the Agent SDK.
+Fetched by `scripts/capture-cli-data.sh` from unpkg CDN.
+
+| File | Captured As | What to Watch For | Elixir Modules Affected |
+|---|---|---|---|
+| `resources/beta/messages/messages.d.ts` | `anthropic-api-messages.d.ts` | **Content block types** | — |
+| ↳ `BetaContentBlock` union | — | New content block types | `content/`, `cli/parser.ex` |
+| ↳ `BetaRawContentBlockDelta` union | — | New delta types for streaming | `content.ex` (delta type) |
+| ↳ `BetaRawMessageStreamEvent` | — | Streaming event structure changes | `cli/parser.ex` |
+
+## Python SDK (`anthropics/claude-agent-sdk-python`)
+
+Full source available on GitHub. Fetched by `scripts/capture-cli-data.sh` via `gh api`.
+
+### Priority 1: Type Definitions & Options
+
+| GitHub Path | Captured As | What to Watch For | Elixir Modules Affected |
+|---|---|---|---|
+| `src/claude_agent_sdk/types.py` | `python-sdk-types.py` | All types, options, MCP configs, hook types, permission types | `options.ex`, `message/`, `content/` |
+| `src/claude_agent_sdk/_cli_version.py` | *(extracted to py-sdk-version.txt)* | Bundled CLI version baseline | `adapter/port/installer.ex` |
+
+### Priority 2: Control Protocol & Parsing
+
+| GitHub Path | Captured As | What to Watch For | Elixir Modules Affected |
+|---|---|---|---|
+| `src/claude_agent_sdk/_internal/query.py` | `python-sdk-query.py` | Control request/response handling, hook dispatch, can_use_tool routing, MCP message routing | `adapter/port.ex`, `cli/control.ex`, `cli/input.ex` |
+| `src/claude_agent_sdk/_internal/message_parser.py` | `python-sdk-message-parser.py` | Message type dispatch, field extraction, new type handling | `cli/parser.ex` |
+| `src/claude_agent_sdk/_internal/client.py` | `python-sdk-client.py` | Option validation, mutual exclusion rules, agent/hook preprocessing | `session/server.ex`, `options.ex` |
+
+### Priority 3: CLI Flag Mapping & Transport
+
+| GitHub Path | Captured As | What to Watch For | Elixir Modules Affected |
+|---|---|---|---|
+| `src/claude_agent_sdk/_internal/transport/subprocess_cli.py` | `python-sdk-subprocess-cli.py` | `_build_command()` flag mappings, binary resolution, env vars | `cli/command.ex`, `adapter/port/resolver.ex` |
+
+### Priority 4: Public API Surface
+
+| GitHub Path | Captured As | What to Watch For | Elixir Modules Affected |
+|---|---|---|---|
+| `src/claude_agent_sdk/client.py` | `python-sdk-public-client.py` | Public client methods (new runtime control, session management) | `session.ex` |
+| `src/claude_agent_sdk/query.py` | *(not captured — thin wrapper)* | Public query function signature | `claude_code.ex` |
+| `src/claude_agent_sdk/__init__.py` | *(not captured — exports only)* | New public exports indicating new features | Various |
+
+### Priority 5: Feature Gap Tracking
+
+| GitHub Path | Captured As | What to Watch For | Elixir Modules Affected |
+|---|---|---|---|
+| `src/claude_agent_sdk/_internal/sessions.py` | *(not captured)* | Session listing/history (not yet in Elixir SDK) | Future feature |
+| `src/claude_agent_sdk/_internal/session_mutations.py` | *(not captured)* | Session rename/tag (not yet in Elixir SDK) | Future feature |
+| `src/claude_agent_sdk/_errors.py` | *(not captured)* | Error type taxonomy | Error tuples |
+
+## Cross-Reference: What Each Check Agent Needs
+
+| Check Agent | Primary Captured Files | Secondary Files |
+|---|---|---|
+| **check-versions** | `cli-version.txt`, `bundled-version.txt`, `ts-sdk-version.txt`, `py-sdk-version.txt`, `anthropic-sdk-version.txt` | — |
+| **check-message-types** | `ts-sdk-types.d.ts` (SDKMessage union), `python-sdk-types.py` (Message union) | `python-sdk-message-parser.py` |
+| **check-content-blocks** | `anthropic-api-messages.d.ts` (BetaContentBlock union) | `ts-sdk-types.d.ts` |
+| **check-control-protocol** | `ts-sdk-types.d.ts` (SDKControl* types), `python-sdk-query.py` (control handling) | `python-sdk-client.py` |
+| **check-options** | `cli-help.txt`, `ts-sdk-types.d.ts` (Options type), `python-sdk-subprocess-cli.py` (_build_command), `python-sdk-types.py` (ClaudeAgentOptions) | `python-sdk-client.py` |

--- a/.claude/skills/cli-sync/scripts/capture-cli-data.sh
+++ b/.claude/skills/cli-sync/scripts/capture-cli-data.sh
@@ -12,7 +12,7 @@
 # What it captures:
 #   - CLI version
 #   - CLI --help output
-#   - Python SDK types.py and subprocess_cli.py (via gh)
+#   - Python SDK types.py, subprocess_cli.py, query.py, message_parser.py, client.py (via gh)
 #   - TypeScript SDK sdk.d.ts type definitions (via npm/unpkg)
 #   - Anthropic API types (BetaRawMessageStreamEvent etc. from @anthropic-ai/sdk)
 #   - SDK version tracking files
@@ -65,19 +65,45 @@ fi
 
 # --- Python SDK via gh ---
 echo "[4/8] Fetching Python SDK sources via gh..."
+PYTHON_REPO="anthropics/claude-agent-sdk-python"
+PYTHON_SRC="src/claude_agent_sdk"
 if command -v gh &> /dev/null; then
     # types.py - canonical message/content type definitions
-    gh api repos/anthropics/claude-agent-sdk-python/contents/src/claude_agent_sdk/types.py --jq '.content' 2>/dev/null | base64 -d \
+    gh api "repos/$PYTHON_REPO/contents/$PYTHON_SRC/types.py" --jq '.content' 2>/dev/null | base64 -d \
         > "$OUTPUT_DIR/python-sdk-types.py" 2>/dev/null || echo "# FAILED to fetch types.py" > "$OUTPUT_DIR/python-sdk-types.py"
     echo "  Done: python-sdk-types.py"
 
     # subprocess_cli.py - CLI flag mapping
-    gh api repos/anthropics/claude-agent-sdk-python/contents/src/claude_agent_sdk/_internal/transport/subprocess_cli.py --jq '.content' 2>/dev/null | base64 -d \
+    gh api "repos/$PYTHON_REPO/contents/$PYTHON_SRC/_internal/transport/subprocess_cli.py" --jq '.content' 2>/dev/null | base64 -d \
         > "$OUTPUT_DIR/python-sdk-subprocess-cli.py" 2>/dev/null || echo "# FAILED to fetch subprocess_cli.py" > "$OUTPUT_DIR/python-sdk-subprocess-cli.py"
     echo "  Done: python-sdk-subprocess-cli.py"
+
+    # query.py - control protocol handling, hook dispatch, can_use_tool routing
+    gh api "repos/$PYTHON_REPO/contents/$PYTHON_SRC/_internal/query.py" --jq '.content' 2>/dev/null | base64 -d \
+        > "$OUTPUT_DIR/python-sdk-query.py" 2>/dev/null || echo "# FAILED to fetch query.py" > "$OUTPUT_DIR/python-sdk-query.py"
+    echo "  Done: python-sdk-query.py"
+
+    # message_parser.py - message type dispatch and field extraction
+    gh api "repos/$PYTHON_REPO/contents/$PYTHON_SRC/_internal/message_parser.py" --jq '.content' 2>/dev/null | base64 -d \
+        > "$OUTPUT_DIR/python-sdk-message-parser.py" 2>/dev/null || echo "# FAILED to fetch message_parser.py" > "$OUTPUT_DIR/python-sdk-message-parser.py"
+    echo "  Done: python-sdk-message-parser.py"
+
+    # client.py (internal) - option validation, mutual exclusion, preprocessing
+    gh api "repos/$PYTHON_REPO/contents/$PYTHON_SRC/_internal/client.py" --jq '.content' 2>/dev/null | base64 -d \
+        > "$OUTPUT_DIR/python-sdk-client.py" 2>/dev/null || echo "# FAILED to fetch _internal/client.py" > "$OUTPUT_DIR/python-sdk-client.py"
+    echo "  Done: python-sdk-client.py"
+
+    # client.py (public) - public client API surface
+    gh api "repos/$PYTHON_REPO/contents/$PYTHON_SRC/client.py" --jq '.content' 2>/dev/null | base64 -d \
+        > "$OUTPUT_DIR/python-sdk-public-client.py" 2>/dev/null || echo "# FAILED to fetch client.py" > "$OUTPUT_DIR/python-sdk-public-client.py"
+    echo "  Done: python-sdk-public-client.py"
 else
     echo "# gh CLI not found - install with: brew install gh" > "$OUTPUT_DIR/python-sdk-types.py"
     echo "# gh CLI not found - install with: brew install gh" > "$OUTPUT_DIR/python-sdk-subprocess-cli.py"
+    echo "# gh CLI not found - install with: brew install gh" > "$OUTPUT_DIR/python-sdk-query.py"
+    echo "# gh CLI not found - install with: brew install gh" > "$OUTPUT_DIR/python-sdk-message-parser.py"
+    echo "# gh CLI not found - install with: brew install gh" > "$OUTPUT_DIR/python-sdk-client.py"
+    echo "# gh CLI not found - install with: brew install gh" > "$OUTPUT_DIR/python-sdk-public-client.py"
     echo "  WARNING: gh CLI not found, skipping Python SDK fetch"
 fi
 


### PR DESCRIPTION
## Summary

- Add `references/upstream-sources.md` mapping all key upstream SDK files (TS, Python, Anthropic API) that need monitoring for schema drift
- Expand `capture-cli-data.sh` to fetch 4 additional Python SDK files: `query.py`, `message_parser.py`, `client.py` (internal), and `client.py` (public)
- Update check agents (`check-control-protocol.md`, `check-message-types.md`, `check-options.md`) to reference the new captured data sources

## Test plan

- [ ] Run `scripts/capture-cli-data.sh` and verify the 4 new Python SDK files are fetched
- [ ] Run `/cli-sync` and confirm agents use the new data sources in their analysis