### PR TITLE
Inject session_id into can_use_tool request

### DIFF
--- a/lib/claude_code/adapter/port.ex
+++ b/lib/claude_code/adapter/port.ex
@@ -638,6 +638,7 @@ defmodule ClaudeCode.Adapter.Port do
           route_hook_callback(request, state.hook_registry, proxy, msg, timeout)
 
         subtype == "can_use_tool" ->
+          request = Map.put(request, "session_id", ClaudeCode.Session.session_id(state.session))
           route_can_use_tool(request, state.hook_registry, proxy, msg, timeout)
 
         true ->
@@ -671,6 +672,7 @@ defmodule ClaudeCode.Adapter.Port do
           {:ok, ControlHandler.handle_mcp_message(server_name, jsonrpc, state.sdk_mcp_servers)}
 
         "can_use_tool" ->
+          request = Map.put(request, "session_id", ClaudeCode.Session.session_id(state.session))
           {:ok, ControlHandler.handle_can_use_tool(request, state.hook_registry)}
 
         "elicitation" ->


### PR DESCRIPTION
I need to access the `session_id` within the `can_use_tool` callbacks and it's not currently available. 

This is probably a hack approach to address this but I'm going to try using this workaround in my fork for now.