### PR TITLE
Fix shell_escape to quote all non-safe characters

### DIFF
--- a/lib/claude_code/adapter/port.ex
+++ b/lib/claude_code/adapter/port.ex
@@ -31,7 +31,9 @@ defmodule ClaudeCode.Adapter.Port do
 
   require Logger
 
-  @shell_special_chars ["'", " ", "\"", "$", "`", "\\", "\n", ";", "&", "|", "(", ")"]
+  # Regex matching strings composed entirely of shell-safe characters.
+  # Anything not matching gets single-quoted for safety.
+  @shell_safe_pattern ~r/\A[a-zA-Z0-9_\-\.\/\:\=\+\@\%\,]+\z/
   @default_control_timeout 60_000
 
   # Keys consumed by Adapter.Port that should never reach CLI command building.
@@ -505,10 +507,8 @@ defmodule ClaudeCode.Adapter.Port do
   end
 
   @doc false
-  # Semicolons must be escaped because they are command separators in shell.
-  # This is critical for system env vars like LS_COLORS that contain semicolons.
   def shell_escape(str) when is_binary(str) do
-    if str == "" or String.contains?(str, @shell_special_chars) do
+    if str == "" or not Regex.match?(@shell_safe_pattern, str) do
       "'" <> String.replace(str, "'", "'\\''") <> "'"
     else
       str

--- a/test/claude_code/adapter/port_test.exs
+++ b/test/claude_code/adapter/port_test.exs
@@ -81,6 +81,48 @@ defmodule ClaudeCode.Adapter.PortTest do
       assert Port.shell_escape(123) == "123"
       assert Port.shell_escape(:atom) == "atom"
     end
+
+    test "escapes strings with angle brackets (redirection)" do
+      assert Port.shell_escape("value<with>redirects") == "'value<with>redirects'"
+    end
+
+    test "escapes strings with square brackets (glob pattern)" do
+      assert Port.shell_escape("value[0]") == "'value[0]'"
+    end
+
+    test "escapes strings with curly braces (brace expansion)" do
+      assert Port.shell_escape("value{a,b}") == "'value{a,b}'"
+    end
+
+    test "escapes strings with exclamation mark (history expansion)" do
+      assert Port.shell_escape("password!123") == "'password!123'"
+    end
+
+    test "escapes strings with hash (comment)" do
+      assert Port.shell_escape("value#comment") == "'value#comment'"
+    end
+
+    test "escapes strings with question mark (glob)" do
+      assert Port.shell_escape("file?.txt") == "'file?.txt'"
+    end
+
+    test "escapes strings with asterisk (glob)" do
+      assert Port.shell_escape("file*.txt") == "'file*.txt'"
+    end
+
+    test "escapes strings with tilde (home expansion)" do
+      assert Port.shell_escape("~user") == "'~user'"
+    end
+
+    test "escapes strings with tab character" do
+      assert Port.shell_escape("val\there") == "'val\there'"
+    end
+
+    test "escapes complex strings with multiple previously-unescaped characters" do
+      # Simulates a generated password/token with many special chars
+      input = "Nk>m]R62!bu#s45#G3?6R<vw]"
+      assert Port.shell_escape(input) == "'Nk>m]R62!bu#s45#G3?6R<vw]'"
+    end
   end
 
   # ============================================================================


### PR DESCRIPTION
## Summary

- Replace fragile `@shell_special_chars` allowlist (12 characters) with `@shell_safe_pattern` safelist regex
- Strings not composed entirely of known-safe characters are now single-quoted by default
- Fixes shell command breakage when env var values contain `!`, `#`, `<`, `>`, `?`, `[`, `]`, `{`, `}`, `*`, `~`, tab, etc.

Fixes #38

## Test plan

- [x] Added 10 new tests for previously-unescaped characters (angle brackets, square brackets, curly braces, `!`, `#`, `?`, `*`, `~`, tab, complex multi-character string)
- [x] Verified new tests fail before the fix
- [x] All 84 port tests pass after the fix
- [x] `mix quality` passes (compile, format, credo, dialyzer)