### PR TITLE
fix: always emit required fields in PermissionDecision wire format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`:can_use_tool` callback returning bare `:allow` or unmessaged `:deny` no longer triggers CLI `ZodError`** — `PermissionDecision.Allow.to_wire/1` now always emits `"updatedInput"` (defaulting to `%{}` when nil), and `PermissionDecision.Deny.to_wire/1` now always emits `"message"` (defaulting to `""` when nil). The Claude CLI's permission-response schema (Zod union) treats both fields as required on their respective arms, so omitting them caused every tool call routed through `can_use_tool` to fail validation. Verified against CLI 2.1.76.
+
 ## [0.36.3] - 2026-03-30 | CC 2.1.76
 
 ### Fixed

--- a/lib/claude_code/hook/permission_decision/allow.ex
+++ b/lib/claude_code/hook/permission_decision/allow.ex
@@ -28,7 +28,10 @@ defmodule ClaudeCode.Hook.PermissionDecision.Allow do
     # `updatedInput` is required by the CLI's permission-response schema (Zod
     # union expects it on the "allow" arm). Default to %{} when the callback
     # didn't supply a replacement input.
-    %{"behavior" => "allow", "updatedInput" => o.updated_input || %{}}
-    |> Output.maybe_put("updatedPermissions", o.updated_permissions)
+    Output.maybe_put(
+      %{"behavior" => "allow", "updatedInput" => o.updated_input || %{}},
+      "updatedPermissions",
+      o.updated_permissions
+    )
   end
 end

--- a/lib/claude_code/hook/permission_decision/allow.ex
+++ b/lib/claude_code/hook/permission_decision/allow.ex
@@ -25,8 +25,10 @@ defmodule ClaudeCode.Hook.PermissionDecision.Allow do
   defstruct [:updated_input, :updated_permissions]
 
   def to_wire(%__MODULE__{} = o) do
-    %{"behavior" => "allow"}
-    |> Output.maybe_put("updatedInput", o.updated_input)
+    # `updatedInput` is required by the CLI's permission-response schema (Zod
+    # union expects it on the "allow" arm). Default to %{} when the callback
+    # didn't supply a replacement input.
+    %{"behavior" => "allow", "updatedInput" => o.updated_input || %{}}
     |> Output.maybe_put("updatedPermissions", o.updated_permissions)
   end
 end

--- a/lib/claude_code/hook/permission_decision/deny.ex
+++ b/lib/claude_code/hook/permission_decision/deny.ex
@@ -21,8 +21,10 @@ defmodule ClaudeCode.Hook.PermissionDecision.Deny do
   defstruct [:message, :interrupt]
 
   def to_wire(%__MODULE__{} = o) do
-    %{"behavior" => "deny"}
-    |> Output.maybe_put("message", o.message)
+    # `message` is required by the CLI's permission-response schema (Zod union
+    # expects a string on the "deny" arm). Default to "" when the callback
+    # didn't supply a reason.
+    %{"behavior" => "deny", "message" => o.message || ""}
     |> Output.maybe_put("interrupt", o.interrupt)
   end
 end

--- a/lib/claude_code/hook/permission_decision/deny.ex
+++ b/lib/claude_code/hook/permission_decision/deny.ex
@@ -24,7 +24,6 @@ defmodule ClaudeCode.Hook.PermissionDecision.Deny do
     # `message` is required by the CLI's permission-response schema (Zod union
     # expects a string on the "deny" arm). Default to "" when the callback
     # didn't supply a reason.
-    %{"behavior" => "deny", "message" => o.message || ""}
-    |> Output.maybe_put("interrupt", o.interrupt)
+    Output.maybe_put(%{"behavior" => "deny", "message" => o.message || ""}, "interrupt", o.interrupt)
   end
 end

--- a/test/claude_code/hook/output_test.exs
+++ b/test/claude_code/hook/output_test.exs
@@ -218,9 +218,9 @@ defmodule ClaudeCode.Hook.OutputTest do
   end
 
   describe "PermissionDecision.Allow.to_wire/1" do
-    test "basic allow" do
+    test "basic allow always emits updatedInput (CLI Zod requires it)" do
       result = Allow.to_wire(%Allow{})
-      assert result == %{"behavior" => "allow"}
+      assert result == %{"behavior" => "allow", "updatedInput" => %{}}
     end
 
     test "allow with updated_input" do
@@ -242,6 +242,7 @@ defmodule ClaudeCode.Hook.OutputTest do
         })
 
       assert result["behavior"] == "allow"
+      assert result["updatedInput"] == %{}
       assert result["updatedPermissions"] == perms
     end
 
@@ -259,9 +260,9 @@ defmodule ClaudeCode.Hook.OutputTest do
   end
 
   describe "PermissionDecision.Deny.to_wire/1" do
-    test "basic deny" do
+    test "basic deny always emits message (CLI Zod requires it)" do
       result = Deny.to_wire(%Deny{})
-      assert result == %{"behavior" => "deny"}
+      assert result == %{"behavior" => "deny", "message" => ""}
     end
 
     test "deny with message" do
@@ -286,13 +287,13 @@ defmodule ClaudeCode.Hook.OutputTest do
       assert result["interrupt"] == true
     end
 
-    test "deny with only interrupt" do
+    test "deny with only interrupt still emits empty message" do
       result =
         Deny.to_wire(%Deny{interrupt: true})
 
       assert result["behavior"] == "deny"
       assert result["interrupt"] == true
-      refute Map.has_key?(result, "message")
+      assert result["message"] == ""
     end
   end
 
@@ -324,7 +325,7 @@ defmodule ClaudeCode.Hook.OutputTest do
   describe "PermissionDecision standalone (can_use_tool)" do
     test "allow via Output.to_wire" do
       result = Output.to_wire(%Allow{})
-      assert result == %{"behavior" => "allow"}
+      assert result == %{"behavior" => "allow", "updatedInput" => %{}}
     end
 
     test "deny via Output.to_wire" do


### PR DESCRIPTION
## Summary

When a `:can_use_tool` callback returns `:allow` (the documented shorthand for "allow this tool"), the resulting wire response is `{"behavior": "allow"}` — missing the `updatedInput` field that Claude CLI ≥ 2.1.76 requires. The CLI rejects the response with `ZodError`, every tool call fails, and the agent has no way to make progress. The same issue affects `{:deny, message: nil}` and any `Deny` struct without a `message`.

Verified on `claude_code` `0.36.3` with bundled CLI `2.1.76`.

## Reproduction

```elixir
{:ok, session} =
  ClaudeCode.start_link(
    cwd: "/tmp/scratch",
    can_use_tool: fn _input, _id -> :allow end
  )

session
|> ClaudeCode.stream("Read package.json and show me the version")
|> ClaudeCode.Stream.collect()
```

Every tool call that goes through `can_use_tool` results in the CLI emitting an error like:

```
ZodError: [{"code":"invalid_union","errors":[
  [{"expected":"record","code":"invalid_type","path":["updatedInput"],"message":"Invalid input: expected record, received undefined"}],
  [{"code":"invalid_value","values":["deny"],"path":["behavior"],"message":"Invalid input: expected \"deny\""},
   {"expected":"string","code":"invalid_type","path":["message"],"message":"Invalid input: expected string, received undefined"}]
]}]
```

Reading both branches: the CLI's permission-response schema is a discriminated union where the `"allow"` arm requires `updatedInput` (a record) and the `"deny"` arm requires `message` (a string). Our `{"behavior": "allow"}` fails the allow arm on missing `updatedInput` and the deny arm on the literal mismatch. The agent then fabricates explanations ("I need permission to run this MCP tool", "settings.json must be misconfigured") and stalls.

## Root cause

`lib/claude_code/hook/permission_decision/allow.ex`:

```elixir
def to_wire(%__MODULE__{} = o) do
  %{"behavior" => "allow"}
  |> Output.maybe_put("updatedInput", o.updated_input)
  |> Output.maybe_put("updatedPermissions", o.updated_permissions)
end
```

`Output.maybe_put/3` skips nil values. The `:allow` shorthand path is:

```elixir
def coerce_permission(:allow), do: %PermissionDecision.Allow{}
```

…which leaves `updated_input` as nil, so it never lands in the wire payload. The Zod schema on the CLI side treats `updatedInput` as required.

`lib/claude_code/hook/permission_decision/deny.ex` has the same shape — a `Deny` struct without a `message` would also produce `{"behavior": "deny"}` and fail validation.

## Expected behavior

`:allow` should produce a wire payload that satisfies the CLI's permission-response schema unconditionally. Either:

- Always emit `updatedInput` (default to `%{}` when nil), or
- Emit the original tool input (the SDK has it in the request) as `updatedInput` when the callback didn't provide an override.

For `Deny`, similarly: emit `message` (default to `""` or some neutral string) when the struct didn't carry one.

## Fix

Default `updated_input` to `%{}` and `message` to `""` in the two `to_wire/1` functions, so the wire payload satisfies the CLI's Zod schema even when the callback doesn't supply those fields. Tests updated.

A richer fix would thread the original tool input through `ControlHandler.handle_can_use_tool/3` so `Allow.to_wire/1` can emit the actual input when the callback returns bare `:allow`. That avoids sending an empty map and matches how the Python SDK behaves — leaving that as a follow-up.

## Related

- 0.32.1 changelog says "corrected … typespec for `:allow`/`:deny` in hook responses" — the typespec may have been corrected but the wire output wasn't.
- Affects anyone using `:can_use_tool` with CLI ≥ 2.1.76. With the bundled CLI version locked at 2.1.76 in 0.36.x this is universal.