### PR TITLE
fix: halt stream on terminal AssistantMessage errors

### DIFF
--- a/lib/claude_code/stream.ex
+++ b/lib/claude_code/stream.ex
@@ -565,16 +565,21 @@ defmodule ClaudeCode.Stream do
     # Use receive_next to get messages from the session (pull-based)
     case GenServer.call(state.session, {:receive_next, state.request_ref}, state.timeout) do
       {:message, message} ->
-        if should_emit?(message, state.filter) do
-          case message do
-            %Message.ResultMessage{} ->
-              {[message], %{state | done: true}}
+        cond do
+          terminal_error?(message) ->
+            {[synthesize_error_result(message)], %{state | done: true}}
 
-            _ ->
-              {[message], state}
-          end
-        else
-          next_message(state)
+          should_emit?(message, state.filter) ->
+            case message do
+              %Message.ResultMessage{} ->
+                {[message], %{state | done: true}}
+
+              _ ->
+                {[message], state}
+            end
+
+          true ->
+            next_message(state)
         end
 
       :done ->
@@ -602,6 +607,25 @@ defmodule ClaudeCode.Stream do
   defp process_alive?({:global, _} = name), do: GenServer.whereis(name) != nil
   defp process_alive?({name, _node} = ref) when is_atom(name), do: GenServer.whereis(ref) != nil
   defp process_alive?(_), do: false
+
+  defp terminal_error?(%Message.AssistantMessage{error: error}) when not is_nil(error), do: true
+  defp terminal_error?(_), do: false
+
+  defp synthesize_error_result(%Message.AssistantMessage{} = msg) do
+    %Message.ResultMessage{
+      type: :result,
+      subtype: msg.error,
+      is_error: true,
+      duration_ms: 0.0,
+      duration_api_ms: 0.0,
+      num_turns: 0,
+      result: to_string(msg),
+      session_id: msg.session_id,
+      total_cost_usd: 0.0,
+      usage: %{},
+      uuid: msg.uuid
+    }
+  end
 
   defp should_emit?(_message, :all), do: true
 

--- a/test/claude_code/session_adapter_test.exs
+++ b/test/claude_code/session_adapter_test.exs
@@ -1,6 +1,7 @@
 defmodule ClaudeCode.SessionAdapterTest do
   use ExUnit.Case, async: true
 
+  alias ClaudeCode.Message.ResultMessage
   alias ClaudeCode.Session
   alias ClaudeCode.Test.Factory
 
@@ -378,6 +379,151 @@ defmodule ClaudeCode.SessionAdapterTest do
       {:ok, session} = Session.start_link(adapter: {HealthyAdapter, [health_status: :degraded]})
 
       assert :degraded = ClaudeCode.Session.health(session)
+
+      GenServer.stop(session)
+    end
+  end
+
+  # ============================================================================
+  # Stream halts on terminal AssistantMessage errors (issue #49)
+  # ============================================================================
+
+  describe "stream halts on terminal assistant errors" do
+    defmodule RateLimitLoopAdapter do
+      @moduledoc false
+      @behaviour ClaudeCode.Adapter
+
+      use GenServer
+
+      alias ClaudeCode.Adapter
+      alias ClaudeCode.Test.Factory
+
+      @impl ClaudeCode.Adapter
+      def start_link(session, opts), do: GenServer.start_link(__MODULE__, {session, opts})
+
+      @impl ClaudeCode.Adapter
+      def send_query(adapter, request_id, _prompt, _opts) do
+        GenServer.cast(adapter, {:query, request_id})
+        :ok
+      end
+
+      @impl ClaudeCode.Adapter
+      def health(_adapter), do: :healthy
+
+      @impl ClaudeCode.Adapter
+      def stop(adapter), do: GenServer.stop(adapter, :normal)
+
+      @impl GenServer
+      def init({session, _opts}) do
+        Process.link(session)
+        Adapter.notify_status(session, :ready)
+        {:ok, %{session: session}}
+      end
+
+      @impl GenServer
+      def handle_cast({:query, request_id}, state) do
+        user_msg =
+          Factory.user_message(
+            message: %{
+              content: [
+                Factory.text_block(
+                  text: "Stop hook feedback:\nYou MUST call the StructuredOutput tool to complete this request."
+                )
+              ]
+            }
+          )
+
+        error_msg =
+          Factory.assistant_message(
+            error: :rate_limit,
+            message: %{
+              model: "<synthetic>",
+              content: [Factory.text_block(text: "You're out of extra usage")],
+              stop_reason: :stop_sequence
+            }
+          )
+
+        for _ <- 1..10 do
+          Adapter.notify_message(state.session, request_id, user_msg)
+          Adapter.notify_message(state.session, request_id, error_msg)
+        end
+
+        {:noreply, state}
+      end
+    end
+
+    test "stream terminates when assistant message has a terminal error" do
+      {:ok, session} = Session.start_link(adapter: {RateLimitLoopAdapter, []})
+
+      messages =
+        session
+        |> ClaudeCode.stream("test")
+        |> Enum.to_list()
+
+      error_msg = List.last(messages)
+      assert %ResultMessage{is_error: true, subtype: :rate_limit} = error_msg
+      assert error_msg.result == "You're out of extra usage"
+
+      GenServer.stop(session)
+    end
+
+    defmodule BillingErrorAdapter do
+      @moduledoc false
+      @behaviour ClaudeCode.Adapter
+
+      use GenServer
+
+      alias ClaudeCode.Adapter
+      alias ClaudeCode.Test.Factory
+
+      @impl ClaudeCode.Adapter
+      def start_link(session, opts), do: GenServer.start_link(__MODULE__, {session, opts})
+
+      @impl ClaudeCode.Adapter
+      def send_query(adapter, request_id, _prompt, _opts) do
+        GenServer.cast(adapter, {:query, request_id})
+        :ok
+      end
+
+      @impl ClaudeCode.Adapter
+      def health(_adapter), do: :healthy
+
+      @impl ClaudeCode.Adapter
+      def stop(adapter), do: GenServer.stop(adapter, :normal)
+
+      @impl GenServer
+      def init({session, _opts}) do
+        Process.link(session)
+        Adapter.notify_status(session, :ready)
+        {:ok, %{session: session}}
+      end
+
+      @impl GenServer
+      def handle_cast({:query, request_id}, state) do
+        Adapter.notify_message(
+          state.session,
+          request_id,
+          Factory.assistant_message(
+            error: :billing_error,
+            message: %{content: [Factory.text_block(text: "Billing issue")]}
+          )
+        )
+
+        {:noreply, state}
+      end
+    end
+
+    test "stream terminates on other error types" do
+      {:ok, session} = Session.start_link(adapter: {BillingErrorAdapter, []})
+
+      messages =
+        session
+        |> ClaudeCode.stream("test")
+        |> Enum.to_list()
+
+      assert length(messages) == 1
+      assert %ResultMessage{is_error: true, subtype: :billing_error} = hd(messages)
+      assert hd(messages).result == "Billing issue"
 
       GenServer.stop(session)
     end


### PR DESCRIPTION
## Summary

- When the CLI hits an unrecoverable error (rate limit, auth failure, billing), it enters an infinite loop emitting synthetic UserMessage/AssistantMessage pairs. The SDK stream never terminates because it only halts on `ResultMessage`.
- Detect `AssistantMessage` with a non-nil `error` field and synthesize a `ResultMessage` with `is_error: true`, preserving the error type as `subtype` and the error text as `result`.
- All existing consumers (`query/2`, `final_text/1`, `collect/1`) handle the synthesized error result correctly with no changes needed.

Closes #49

## Test plan

- [x] New test: `RateLimitLoopAdapter` simulates 10 iterations of the rate-limit loop, asserts stream terminates with `%ResultMessage{is_error: true, subtype: :rate_limit}`
- [x] New test: `BillingErrorAdapter` verifies other error types also terminate correctly
- [x] Full test suite passes (1493 tests, 0 failures)
- [x] `mix quality` passes (compile, format, credo, dialyzer)