### PR TITLE
feat: expose --exclude-dynamic-system-prompt-sections

### DIFF
--- a/lib/claude_code/cli/command.ex
+++ b/lib/claude_code/cli/command.ex
@@ -269,6 +269,12 @@ defmodule ClaudeCode.CLI.Command do
 
   defp convert_option(:include_partial_messages, false), do: nil
 
+  defp convert_option(:exclude_dynamic_system_prompt_sections, true) do
+    ["--exclude-dynamic-system-prompt-sections"]
+  end
+
+  defp convert_option(:exclude_dynamic_system_prompt_sections, false), do: nil
+
   defp convert_option(:replay_user_messages, true) do
     ["--replay-user-messages"]
   end

--- a/lib/claude_code/options.ex
+++ b/lib/claude_code/options.ex
@@ -106,12 +106,13 @@ defmodule ClaudeCode.Options do
 
   ### Output & Streaming
 
-  | Option                     | Type    | Default | Description |
-  | -------------------------- | ------- | ------- | ----------- |
-  | `output_format`            | map     | -       | Structured output: `%{type: :json_schema, schema: schema_map}`. See [Structured Outputs](structured-outputs.md) |
-  | `include_partial_messages` | boolean | false   | Include partial message chunks for character-level streaming. See [Streaming Output](streaming-output.md) |
-  | `replay_user_messages`     | boolean | false   | Re-emit user messages from stdin back on stdout for acknowledgment |
-  | `prompt_suggestions`       | boolean | false   | Emit predicted next user prompts after each turn |
+  | Option                                    | Type    | Default | Description |
+  | ----------------------------------------- | ------- | ------- | ----------- |
+  | `output_format`                           | map     | -       | Structured output: `%{type: :json_schema, schema: schema_map}`. See [Structured Outputs](structured-outputs.md) |
+  | `include_partial_messages`                | boolean | false   | Include partial message chunks for character-level streaming. See [Streaming Output](streaming-output.md) |
+  | `replay_user_messages`                    | boolean | false   | Re-emit user messages from stdin back on stdout for acknowledgment |
+  | `prompt_suggestions`                      | boolean | false   | Emit predicted next user prompts after each turn |
+  | `exclude_dynamic_system_prompt_sections`  | boolean | false   | Move per-machine sections (cwd, env info, memory paths, git status) out of the system prompt and into the first user message. Improves cross-session prompt-cache reuse. Only applies with the default system prompt (ignored with `:system_prompt`). |
 
   ### Settings & Plugins
 
@@ -432,6 +433,15 @@ defmodule ClaudeCode.Options do
       type: :boolean,
       default: false,
       doc: "Include partial message chunks as they arrive for character-level streaming"
+    ],
+    exclude_dynamic_system_prompt_sections: [
+      type: :boolean,
+      default: false,
+      doc:
+        "Move per-machine sections (cwd, env info, memory paths, git status) out of the " <>
+          "system prompt and into the first user message. Improves prompt-cache reuse across " <>
+          "sessions that share a project. Only applies with the default system prompt " <>
+          "(ignored when :system_prompt is set)."
     ],
     replay_user_messages: [
       type: :boolean,

--- a/test/claude_code/cli/command_test.exs
+++ b/test/claude_code/cli/command_test.exs
@@ -637,6 +637,22 @@ defmodule ClaudeCode.CLI.CommandTest do
       refute "--include-partial-messages" in args
     end
 
+    test "converts exclude_dynamic_system_prompt_sections true to --exclude-dynamic-system-prompt-sections" do
+      opts = [exclude_dynamic_system_prompt_sections: true]
+
+      args = Command.to_cli_args(opts)
+      assert "--exclude-dynamic-system-prompt-sections" in args
+      # Boolean flag should not have a value
+      refute "true" in args
+    end
+
+    test "does not add flag when exclude_dynamic_system_prompt_sections is false" do
+      opts = [exclude_dynamic_system_prompt_sections: false]
+
+      args = Command.to_cli_args(opts)
+      refute "--exclude-dynamic-system-prompt-sections" in args
+    end
+
     test "combines include_partial_messages with other options" do
       opts = [
         include_partial_messages: true,

--- a/test/claude_code/options_test.exs
+++ b/test/claude_code/options_test.exs
@@ -67,6 +67,22 @@ defmodule ClaudeCode.OptionsTest do
       assert validated[:include_partial_messages] == false
     end
 
+    test "validates exclude_dynamic_system_prompt_sections option" do
+      opts = [exclude_dynamic_system_prompt_sections: true]
+      assert {:ok, validated} = Options.validate_session_options(opts)
+      assert validated[:exclude_dynamic_system_prompt_sections] == true
+
+      opts = [exclude_dynamic_system_prompt_sections: false]
+      assert {:ok, validated} = Options.validate_session_options(opts)
+      assert validated[:exclude_dynamic_system_prompt_sections] == false
+    end
+
+    test "defaults exclude_dynamic_system_prompt_sections to false" do
+      opts = []
+      assert {:ok, validated} = Options.validate_session_options(opts)
+      assert validated[:exclude_dynamic_system_prompt_sections] == false
+    end
+
     test "validates control_timeout option" do
       assert {:ok, validated} = Options.validate_session_options(control_timeout: 60_000)
       assert validated[:control_timeout] == 60_000


### PR DESCRIPTION
Add the :exclude_dynamic_system_prompt_sections boolean option and plumb it through to the CLI's --exclude-dynamic-system-prompt-sections flag. The flag moves per-machine sections (cwd, env info, memory paths, git status) out of the system prompt and into the first user message, improving prompt-cache reuse across sessions that share a project.

Only applies with the default system prompt (ignored when :system_prompt is set) — matches the CLI's own semantics.

Follows the existing boolean-flag pattern used by
:include_partial_messages / :replay_user_messages, so the CLI conversion + tests read identically.